### PR TITLE
Close out Milestone 2 in repository docs

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,66 +1,63 @@
 # Milestones
 
-## Current Major Milestone: v1.1 Problem-Centered Learning Loop Core
+## Current Major Milestone: v1.2 Learning Asset Evolution
 
-**Status:** Current repository milestone
+**Status:** Functionally complete, ready to close out
 **Last updated:** 2026-03-09
 
 ### Definition
 
-This milestone is the point where Cogniforge behaves primarily like a structured learning loop, not a generic multi-tool workspace.
+This milestone is the point where Cogniforge not only behaves like a structured learning loop, but also treats recall and reinforcement as forces that shape durable knowledge assets.
 
 The milestone is considered present in the current repository because the codebase now has all of the following:
 
-1. `Problems` and `ProblemDetail` are the primary active-learning surfaces.
-2. `socratic` and `exploration` are modeled explicitly across the backend and frontend.
-3. Learning turns can produce structured outputs:
-   - mastery and progression signals
-   - derived concept candidates
-   - derived learning path candidates
-   - review handoff state
-4. Main path, branch path, prerequisite path, and comparison path relationships are navigable.
-5. Accepted concepts can be promoted into model cards.
-6. Review items are traceable back to their originating problem and turn context.
-7. Recall outcomes are visible as consequences in the workspace and model-card surfaces.
+1. Weak recall produces durable reinforcement targets instead of only display text.
+2. Reinforcement resume can return the learner to the right problem, branch path, and focused target in `ProblemDetail`.
+3. `ProblemDetail` can suggest a concrete first reinforcement action.
+4. Reinforcement starters can be grounded by:
+   - source-turn context
+   - likely confusion / error assertions
+   - focused candidate evidence when the signal is strong enough
+5. Model cards now reflect recall / reinforcement as explicit asset state, not only as timeline events.
+6. `ModelCardDetail` now surfaces lightweight revision focus hints derived from current recall / reinforcement signals.
 
 ### What This Milestone Is Not
 
 This milestone does not imply:
 
-- a fully mature review system
 - automatic model-card rewriting from recall
-- a generic chat-first product
-- a PKM-style notes/resources product
+- a broad adaptive tutoring engine
+- a full model-card editing workflow
 - broad analytics or admin expansion
 
 ### Main Evidence In The Repo
 
-- Frontend navigation is focused on `Learn`, `Problems`, `Model Cards`, and `Reviews`.
 - `ProblemDetail` is the main learning workspace.
-- Core domain models include `ProblemTurn`, `LearningPath`, `ProblemConceptCandidate`, `ProblemPathCandidate`, and `ReviewSchedule`.
+- Recall and reinforcement now flow back into the workspace, model-card surfaces, and revision hints.
 - Recent commits have tightened:
-  - workspace unification
-  - review origin traceability
-  - recall consequence visibility
+  - adaptive reinforcement targeting
+  - source/error/evidence-aware starters
+  - model-card evolution state and revision focus
 
-## Next Major Milestone: v1.2 Learning Asset Evolution
+## Next Major Milestone: v1.3 Guided Knowledge Revision
 
 ### Brief Definition
 
-The next milestone should make learning and recall update durable knowledge assets more deliberately.
+The next milestone should turn current state and revision-focus hints into a lightweight, traceable knowledge-revision workflow.
 
 ### Expected Focus
 
-1. use recall results to drive clearer follow-up actions back into the right problem/path context
-2. tighten how model cards evolve from learning and recall evidence
-3. improve review prioritization based on recent weakness or stability
+1. make revision focus hints lead to small explicit editing actions in `ModelCardDetail`
+2. keep revision changes traceable to learning, reinforcement, and recall evidence
+3. feed revision outcomes back into the learning / review loop without broadening the product surface
 
 ### Not A Goal
 
 - adding broad new product surfaces
 - redesigning the whole review system
+- automatic model-card rewriting
 - reviving generic chat or PKM-centric identity
 
 ## Historical Note
 
-The repository previously tracked an older `v1.0` milestone around cognitive adversarial testing. That work remains in the codebase, but it is no longer the best description of the product's current center of gravity. The current milestone definition is now based on the structured learning loop that dominates the active product surface and recent implementation work.
+The repository previously tracked `v1.1` as the current milestone. That is now best understood as the foundation milestone that established the problem-centered learning loop. The current milestone definition has moved to `v1.2` because the repository now contains the main adaptive reinforcement and learning-asset evolution chain.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,8 +1,7 @@
----
-gsd_state_version: 1.1
-milestone: v1.1
-milestone_name: problem-centered-learning-loop-core
-status: active
+gsd_state_version: 1.2
+milestone: v1.2
+milestone_name: learning-asset-evolution
+status: functionally-complete
 last_updated: "2026-03-09T00:00:00Z"
 ---
 
@@ -10,15 +9,15 @@ last_updated: "2026-03-09T00:00:00Z"
 
 ## Current Position
 
-**Current major milestone:** `v1.1 Problem-Centered Learning Loop Core`
-**Status:** Active repository milestone
-**Current focus:** Keep tightening the main learning loop around `ProblemDetail`, model-card handoff, and review / recall consequences.
+**Current major milestone:** `v1.2 Learning Asset Evolution`
+**Status:** Functionally complete, ready to close out
+**Current focus:** Close out Milestone 2 clearly and prepare for Milestone 3 planning without re-expanding product scope.
 
 ## Working Definition
 
-The repository is currently centered on a single core flow:
+The repository is currently centered on a single adaptive learning flow:
 
-`Problems -> ProblemDetail -> derived concepts / derived paths -> Model Cards -> Reviews / Recall`
+`Problems -> ProblemDetail -> Reviews / Recall -> reinforcement -> Model Cards -> revision focus`
 
 This means:
 
@@ -27,28 +26,30 @@ This means:
 3. Learning turns generate structured artifacts that can be governed and revisited.
 4. Branch learning paths remain traceable back to the main path.
 5. Review and recall are part of the same learning loop, not detached modules.
+6. Weak recall can now return the learner to the right path, target, starter, and linked model card context.
+7. Model cards now expose explicit asset state and a lightweight revision direction.
 
 ## Repository Signals Supporting This State
 
 - Frontend primary navigation is focused on `Learn`, `Problems`, `Model Cards`, and `Reviews`.
-- Review and recall surfaces now display origin and consequence data.
+- Review and recall surfaces now display origin, consequence, and reinforcement data.
 - Recent commits have emphasized:
-  - product-surface shrink
-  - main workspace unification
-  - recall continuity
-  - recall consequence visibility
+  - path-precise reinforcement resume
+  - source/error/evidence-aware starters
+  - model-card evolution state
+  - revision focus hints
 
 ## Current Known Gaps
 
-These are still outside the current milestone's completion bar:
+These are still intentionally outside the current milestone's completion bar:
 
-1. recall outcomes do not yet directly rewrite model-card content
-2. review prioritization is still relatively simple
-3. some secondary / legacy surfaces still remain in the codebase
-4. path suggestions are not yet strongly driven by recall outcomes
+1. recall outcomes do not automatically rewrite model-card content
+2. revision focus hints do not yet form a full edit workflow
+3. review prioritization is still relatively simple
+4. some secondary / legacy surfaces still remain in the codebase
 
 ## Next Milestone Direction
 
-The next major milestone should be `v1.2 Learning Asset Evolution`.
+The next major milestone should be `v1.3 Guided Knowledge Revision`.
 
-That milestone should focus on making learning evidence and recall evidence shape model cards and follow-up learning actions more deliberately, without re-expanding the product surface.
+That milestone should focus on making current revision guidance actionable in a lightweight, traceable way, without re-expanding the product surface or introducing automatic rewriting.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,51 +1,48 @@
-# Cogniforge 功能增强开发计划
+# Cogniforge Plan
 
-## 最新专项计划（2026-03-05）
-- 学习闭环与知识治理优化计划：`docs/plans/2026-03-05-learning-loop-hardening-plan.md`
+## Current Milestone
 
-## 阶段一：P0 核心功能（本次实现）
+### v1.2 Learning Asset Evolution
 
-### 1.1 认知演化时间线
-- **后端**: 完善 `EvolutionLog` 持久化，新增演化对比 API
-- **前端**: Model Card 详情页增加演化时间线组件
-- **文件变更**:
-  - `las_backend/app/api/routes/model_cards.py` - 新增演化日志 API
-  - `las_backend/app/services/model_os_service.py` - 完善 log_evolution
-  - `las_backend/app/models/schemas/model_card.py` - 演化日志 schema
-  - `las_frontend/src/views/ModelCardDetailView.vue` - 新建详情页
-  - `las_frontend/src/router/index.ts` - 新增路由
+Status: Functionally complete, ready to close out.
 
-### 1.2 间隔重复系统（SRS）
-- **后端**: 新增 ReviewSchedule 模型，基于 SM-2 算法的复习调度
-- **前端**: Dashboard 显示待复习卡片，复习交互界面
-- **文件变更**:
-  - `las_backend/app/models/entities/user.py` - 新增 ReviewSchedule 模型
-  - `las_backend/app/models/schemas/model_card.py` - 复习调度 schema
-  - `las_backend/app/api/routes/reviews.py` - 新建间隔复习 API
-  - `las_backend/app/services/srs_service.py` - SM-2 算法服务
-  - `las_frontend/src/views/SRSReviewView.vue` - 复习界面
-  - `las_frontend/src/views/DashboardView.vue` - 增加待复习提醒
+This milestone established the adaptive reinforcement loop on top of the Milestone 1 learning core:
 
-### 1.3 学习数据仪表盘增强
-- **后端**: 新增统计 API（热力图数据、认知覆盖度）
-- **前端**: Dashboard 重构，增加图表组件
-- **文件变更**:
-  - `las_backend/app/api/routes/statistics.py` - 新建统计 API
-  - `las_frontend/src/views/DashboardView.vue` - 增强仪表盘
+- weak recall now creates durable reinforcement targets
+- reinforcement resume can return to the right problem and path context
+- ProblemDetail can focus the learner on the right concept/turn/outcome
+- ProblemDetail suggests a concrete first reinforcement action
+- starters are grounded by source-turn context, likely confusion, and focused evidence when the signal is strong enough
+- model cards now show clearer learning-asset state and revision-focus hints
 
-## 阶段二：P1 重要功能
+Working chain:
 
-### 2.1 知识图谱可视化
-### 2.2 多模态输入（PDF 解析）
-### 2.3 主动式认知挑战
+`Problems -> ProblemDetail -> Reviews / Recall -> reinforcement target -> focused workspace recovery -> Model Cards -> revision focus`
 
-## 阶段三：P2 增值功能
+Out of scope for v1.2:
 
-### 3.1 结构化导出（Markdown/Anki）
-### 3.2 学习目标与里程碑
-### 3.3 个性化学习风格适配
+- automatic model-card rewriting
+- a broad practice or tutoring engine
+- large mastery analytics dashboards
+- generic PKM or chat expansion
 
-## 阶段四：P3 社交功能
+## Next Milestone
 
-### 4.1 Model Card 分享
-### 4.2 学习小组
+### v1.3 Guided Knowledge Revision
+
+Direction only. Not started yet.
+
+This milestone should focus on turning current reinforcement and revision signals into lightweight, traceable revision workflows without broadening the product surface.
+
+Likely focus:
+
+- make revision focus hints easier to act on in the existing model-card workflow
+- keep revision actions traceable to recall and reinforcement evidence
+- tighten the handoff between active learning, reinforcement, and durable knowledge revision
+
+Still out of scope unless explicitly pulled in:
+
+- automatic content rewriting
+- broad review-system redesign
+- new standalone training surfaces
+- broad dashboard or multi-tool expansion

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ This repository is not currently centered on generic chat, note-taking, or PKM-s
 
 ## Current Major Milestone
 
-### v1.1 Problem-Centered Learning Loop Core
+### v1.2 Learning Asset Evolution
 
 This is the current major milestone for the repository.
 
-It means the codebase now supports an end-to-end core learning loop with these properties:
+It means the codebase now supports a stronger end-to-end learning loop where recall and reinforcement shape durable knowledge assets, not just review queues.
+
+The milestone is functionally complete enough to close out. It does not mean every adaptive or editing workflow is finished, but it does mean the main Milestone 2 chain is present in the repository.
+
+The current codebase now has all of the following:
 
 1. `ProblemDetail` is the main place for active learning.
 2. Learning modes are explicit first-class concepts:
@@ -33,7 +37,10 @@ It means the codebase now supports an end-to-end core learning loop with these p
 4. Main path and branch path relationships are navigable and traceable.
 5. Accepted concepts can be promoted into model cards and scheduled into recall.
 6. Review items are traceable back to their problem and turn origins.
-7. Recall outcomes now feed back into workspace and model-card state as visible stability and next-action signals.
+7. Weak recall now produces durable reinforcement targets that point back to the right problem, path, and focus target.
+8. `ProblemDetail` can resume the learner into the right branch context and suggest a concrete first reinforcement action.
+9. Reinforcement starters are grounded by source-turn context, likely confusion, and focused candidate evidence when the signal is reliable.
+10. Model cards now reflect recall and reinforcement as explicit knowledge-asset state and lightweight revision-focus hints.
 
 In practical terms, the current repo already contains:
 
@@ -43,29 +50,34 @@ In practical terms, the current repo already contains:
 - branch/return learning-path support
 - model-card handoff and review scheduling from problem outcomes
 - recall origin and recall consequence display in workspace and model-card surfaces
+- path-precise reinforcement resume targeting
+- target-precise reinforcement focus and starter guidance inside `ProblemDetail`
+- explicit model-card evolution state and revision focus hints
 
 What this milestone does not mean:
 
 - the app is a generic AI chat product
 - the app is a note manager or file manager
 - recall automatically rewrites model-card content
+- the system contains a broad adaptive tutoring engine
 - the review system is fully mature or deeply adaptive
 
 ## Next Milestone
 
-### v1.2 Learning Asset Evolution
+### v1.3 Guided Knowledge Revision
 
-The next milestone should focus on tightening how learning and recall update durable knowledge assets.
+The next milestone should focus on turning the current guidance and state signals into lightweight, traceable revision workflows for durable knowledge assets.
 
 In scope for that milestone:
 
-1. make weak recall route learners back to the right problem/path context more precisely
-2. use learning and recall evidence to drive model-card evolution more deliberately
-3. improve how review priority and follow-up actions are derived from recent outcomes
+1. make revision focus hints lead to small, explicit model-card revision actions
+2. keep revision changes traceable to learning, recall, and reinforcement evidence
+3. tighten the connection between revision outcomes and subsequent review / reinforcement behavior
 
 Out of scope for that milestone:
 
 - broad new product surfaces
+- automatic model-card rewriting
 - generic analytics expansion
 - unrelated admin or tooling work
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -4,11 +4,12 @@
 
 ## Current Major Milestone
 
-### v1.1 Problem-Centered Learning Loop Core
+### v1.2 Learning Asset Evolution
 
 This is the current major milestone for the repository.
 
 It reflects the codebase as it exists now, not an aspirational product description.
+The milestone is functionally complete enough to close out.
 
 ## What Is Implemented
 
@@ -43,36 +44,56 @@ The current learning flow can already produce:
 - Model cards can be scheduled into review.
 - Review items are traceable back to the originating problem and learning turn.
 
-### 6. Recall Consequence Visibility
+### 6. Reinforcement Routing
 
-- Recall is no longer only about queue/origin visibility.
-- The current repo now surfaces recall consequences such as:
-  - stability state
-  - recent recall outcome
-  - recommended next action
-- Those signals are visible in:
-  - `ProblemDetail`
-  - derived concept handoff state
-  - model-card surfaces
-  - recall session outcome UI
+- Weak recall now creates durable reinforcement targets.
+- Those targets can return the learner to:
+  - the right problem
+  - the right learning path
+  - the right focused concept / turn
+- `ProblemDetail` can show a concrete first reinforcement action.
+
+### 7. Source / Error / Evidence Grounding
+
+- Reinforcement starters are no longer generic.
+- The current repo can ground them by:
+  - source-turn context
+  - likely confusion / error assertions
+  - focused candidate evidence when the signal is reliable
+
+### 8. Model-Card Evolution State
+
+- Model cards no longer show only review presence and timeline events.
+- The current repo now surfaces model-card state such as:
+  - needs revision
+  - rebuilding
+  - reinforced recently
+  - stable base
+  - first recall queued
+  - repeated confusion
+
+### 9. Revision Direction Hints
+
+- `ModelCardDetail` now shows a lightweight revision focus hint.
+- The hint uses current recall / reinforcement / evolution signals to point toward a first revision direction without rewriting the card automatically.
 
 ## What Is Still Thin
 
 These areas are still intentionally limited:
 
 1. recall does not automatically rewrite model-card content
-2. review prioritization is still lightweight
-3. model evolution is present, but recall-driven evolution is not yet a strong closed loop
+2. revision focus hints are not yet a full revision workflow
+3. review prioritization is still lightweight
 4. legacy / secondary surfaces still exist in the codebase
 
 ## Next Milestone
 
-### v1.2 Learning Asset Evolution
+### v1.3 Guided Knowledge Revision
 
-The next milestone should focus on turning learning evidence and recall evidence into more deliberate model-card evolution and follow-up learning actions.
+The next milestone should focus on turning the current state and revision-focus hints into lightweight, traceable knowledge-revision actions.
 
 The expected center of gravity for that milestone is:
 
-- stronger feedback from weak recall back into the right workspace context
-- clearer model-card evolution from learning and recall evidence
-- better review prioritization without broadening the product surface
+- turning revision focus hints into explicit edit intent
+- keeping revisions traceable to learning / recall evidence
+- feeding revision outcomes back into the learning loop without broadening the product surface


### PR DESCRIPTION
## Summary\n- update the repository docs to mark v1.2 Learning Asset Evolution as functionally complete\n- align milestone, state, and implementation-status docs with the current product state\n- define the next milestone as v1.3 Guided Knowledge Revision without starting implementation\n\n## Validation\n- git diff --check -- README.md PLAN.md .planning/MILESTONES.md .planning/STATE.md docs/implementation-status.md\n